### PR TITLE
Translate empty state messages in calorie tracking page

### DIFF
--- a/heatHMobile/app/(tabs)/calorie.tsx
+++ b/heatHMobile/app/(tabs)/calorie.tsx
@@ -1047,10 +1047,10 @@ export default function CalorieScreen() {
                 <View style={styles.emptyContainer}>
                     <Ionicons name="nutrition-outline" size={64} color={colors.gray[300]} />
                     <Text style={[styles.emptyText, { fontFamily: fonts.medium, color: textColors.secondary }]}>
-                        No entries for this day
+                        {t('calorie.noEntriesForThisDay')}
                     </Text>
                     <Text style={[styles.emptySubText, { fontFamily: fonts.regular, color: textColors.disabled }]}>
-                        Tap + to track your calories
+                        {t('calorie.tapToTrackCalories')}
                     </Text>
                 </View>
             }

--- a/heatHMobile/locales/en/translation.json
+++ b/heatHMobile/locales/en/translation.json
@@ -279,6 +279,8 @@
     "calories": "Calories",
     "protein": "Protein",
     "fat": "Fat",
-    "carbs": "Carbs"
+    "carbs": "Carbs",
+    "noEntriesForThisDay": "No entries for this day",
+    "tapToTrackCalories": "Tap + to track your calories"
   }
 }

--- a/heatHMobile/locales/ja/translation.json
+++ b/heatHMobile/locales/ja/translation.json
@@ -279,6 +279,8 @@
     "calories": "カロリー",
     "protein": "タンパク質",
     "fat": "脂質",
-    "carbs": "炭水化物"
+    "carbs": "炭水化物",
+    "noEntriesForThisDay": "この日のエントリはありません",
+    "tapToTrackCalories": "カロリーを追跡するには + をタップしてください"
   }
 }

--- a/heatHMobile/locales/tr/translation.json
+++ b/heatHMobile/locales/tr/translation.json
@@ -279,6 +279,8 @@
     "calories": "Kalori",
     "protein": "Protein",
     "fat": "Yağ",
-    "carbs": "Karbonhidrat"
+    "carbs": "Karbonhidrat",
+    "noEntriesForThisDay": "Bu gün için giriş yok",
+    "tapToTrackCalories": "Kalorilerinizi takip etmek için + butonuna dokunun"
   }
 }


### PR DESCRIPTION
**Summary:**
- 4 files changed
- 11 insertions, 5 deletions
- Commit hash: `01da767`
- Pushed to: `origin/mobile-calorie-translation`

**Changes included:**
1. Added translation for "No entries for this day" message
2. Added translation for "Tap + to track your calories" message
3. Updated all three language files (English, Turkish, Japanese)
4. Updated calorie page to use translation keys instead of hardcoded text
