### PR TITLE
Updated the app to support the new measurement units end to end.

### DIFF
--- a/heatHBack/src/main/java/heatH/heatHBack/model/MeasurementTypes.java
+++ b/heatHBack/src/main/java/heatH/heatHBack/model/MeasurementTypes.java
@@ -3,7 +3,6 @@ package heatH.heatHBack.model;
 public enum MeasurementTypes {
     GRAM(1.0),
     ML(1.0),
-    PIECE(1.0),
     TEASPOON(5.0),
     TABLESPOON(10.0),
     CUP(200.0);

--- a/heatHFront/React-Web/web/src/pages/RecipeDetail.js
+++ b/heatHFront/React-Web/web/src/pages/RecipeDetail.js
@@ -45,7 +45,6 @@ const LANGUAGE_LABEL_KEYS = {
 const UNIT_LABELS = {
   GRAM: 'g',
   ML: 'ml',
-  PIECE: 'piece',
   TEASPOON: 'tsp',
   TABLESPOON: 'tbsp',
   CUP: 'cup',

--- a/heatHFront/React-Web/web/src/pages/myRecipes.js
+++ b/heatHFront/React-Web/web/src/pages/myRecipes.js
@@ -37,7 +37,6 @@ const initialRecipes = [
 const MEASUREMENT_OPTIONS = [
   { value: 'GRAM', label: 'g' },
   { value: 'ML', label: 'ml' },
-  { value: 'PIECE', label: 'piece' },
   { value: 'TEASPOON', label: 'tsp' },
   { value: 'TABLESPOON', label: 'tbsp' },
   { value: 'CUP', label: 'cup' },


### PR DESCRIPTION
- Added unit selection to recipe creation/editing: heatHFront/React-Web/web/src/pages/myRecipes.js now lets users pick g/ml/tsp/tbsp/cup for each ingredient, carries the unit in state/payload, and shows chips with readable labels; edit flow now parses existing ingredients with units.
- Improved ingredient display: heatHFront/React-Web/web/src/pages/RecipeDetail.js normalizes ingredient data (objects or strings) and renders quantity plus unit using consistent labels.
- Closes [#561 ](https://github.com/bounswe/bounswe2025group7/issues/561)